### PR TITLE
Fixing issues with header handling and condition checking

### DIFF
--- a/crlfsuite/core/scanner.py
+++ b/crlfsuite/core/scanner.py
@@ -21,11 +21,11 @@ def scanner(url, method, cookie, timeout, data, ssl, headers, verbose, silent, s
                         delay,
                 )
     try:
-        text ,status_code, rheaders = response[0], response[1], str(response[2])
+        text ,status_code, rheaders = response[0], response[1], response[2]
     except TypeError:
         pass
     if not int(status_code) >= 400:
-        if 'nefcore' and 'crlfsuite' in rheaders:
+        if 'nefcore' in rheaders or 'crlfsuite' in rheaders:
             vuln_urls.add(url)
         if "svg/onload=alert(innerHTML()" in text:
             vuln_urls.add(url)


### PR DESCRIPTION
Hello,

I noticed two issues in the code you provided:

- The line `str(response[2])` converts the headers object to a string, which can cause problems when checking for specific header names.

- The line if `nefcore` and `crlfsuite` in `rheaders`: checks for the presence of both `nefcore` and `crlfsuite` in the headers. However, the way this is written means that `nefcore` is always evaluated as True, regardless of whether it is actually present in the headers.

To fix these issues, I suggest the following changes:

Replace `str(response[2])` with `response[2]` to use the original headers object instead of the string representation.
Change `if 'nefcore' and 'crlfsuite' in rheaders:` to `if 'nefcore' in rheaders or 'crlfsuite' in rheaders:` to check for the presence of either 'nefcore' or 'crlfsuite' in the headers name.